### PR TITLE
Migrate to Bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ plugins:
     - catalog
     - discover
     settings:
-    - name: user_token
-      kind: password
-    - name: user_email
+    - name: api_token
       kind: password
 ```
 
@@ -76,9 +74,9 @@ Notes:
 
 ### Source Authentication and Authorization
 
-You will need authentication tokens set up in your Workato account. Namely a user 
-email and a user token. See the 
-instructions [here](https://docs.workato.com/oem/oem-api.html#authentication).
+You will need an API token set up in your Workato account. The token is passed as a 
+Bearer token in the Authorization header. See the 
+instructions [here](https://docs.workato.com/workato-api.html#authentication).
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-workato"
-version = "0.1.1"
+version = "0.2.0"
 description = "`tap-workato` is a Singer tap for Workato, built with the Meltano SDK for Singer Taps."
 authors = ["Josh Lloyd"]
 keywords = [

--- a/tap_workato/client.py
+++ b/tap_workato/client.py
@@ -22,8 +22,7 @@ class WorkatoStream(RESTStream):
     def http_headers(self) -> dict:
         """Return the http headers needed."""
         return {
-            "x-user-token": self.config.get("user_token"),
-            "x-user-email": self.config.get("user_email"),
+            "Authorization": f"Bearer {self.config.get('api_token')}",
         }
 
     def get_next_page_token(

--- a/tap_workato/tap.py
+++ b/tap_workato/tap.py
@@ -57,22 +57,11 @@ class TapWorkato(Tap):
 
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "user_token",
+            "api_token",
             th.StringType,
             required=True,
-            description="The token to authenticate against the Workato API service",
+            description="Bearer token for Workato API authentication",
         ),
-        th.Property(
-            "user_email",
-            th.StringType,
-            required=True,
-            description="The email address of the user paired with the token.",
-        ),
-        # th.Property(
-        #     "start_date", stopped_after in recipes?
-        #     th.DateTimeType,
-        #     description="The earliest record date to sync"
-        # ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
## Summary
- Migrate from deprecated `x-user-token`/`x-user-email` headers to Bearer token auth
- Config now requires `api_token` instead of `user_token` and `user_email`
- Bump version to 0.2.0

## Breaking Change
This is a breaking change - existing configurations need to be updated:

**Before:**
```yaml
TAP_WORKATO_USER_TOKEN: xxx
TAP_WORKATO_USER_EMAIL: xxx
```

**After:**
```yaml
TAP_WORKATO_API_TOKEN: xxx
```

## References
- https://docs.workato.com/workato-api.html#authentication

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>